### PR TITLE
Add canary-release action.

### DIFF
--- a/canary-release/README.md
+++ b/canary-release/README.md
@@ -75,4 +75,3 @@ jobs:
           # the GitHub user account that comment with
           # comment-author: conda-bot
 ```
-a

--- a/canary-release/README.md
+++ b/canary-release/README.md
@@ -73,5 +73,5 @@ jobs:
           # comment-token: ${{ secrets.CANARY_ACTION_COMMENT_TOKEN }}
           # [optional]
           # the GitHub user account that comment with
-          # comment-author: conda-bot
+          # comment-headline: Canary release status
 ```

--- a/canary-release/README.md
+++ b/canary-release/README.md
@@ -1,0 +1,78 @@
+# Canary release
+
+This is a custom GitHub action to be used in the conda GitHub organization
+for doing development/canary releases to anaconda.org.
+
+## GitHub Action Usage
+
+In your GitHub repository include the action in your workflows,
+e.g. for doing canary release for when changes are merged into the main
+branch:
+
+```yaml
+name: Canary builds
+
+on:
+  workflow_run:
+    workflows:
+      - CI tests
+    branches:
+      - main
+    types:
+      - completed
+
+jobs:
+  build:
+    if: github.event.workflow_run.conclusion == 'success'
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            subdir: linux-64
+          - runner: macos-latest
+            subdir: osx-64
+          - runner: windows-latest
+            subdir: win-64
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+          clean: true
+          fetch-depth: 0
+
+      - name: Create and upload canary build
+        uses: conda/actions/canary-release
+        with:
+          # [required]
+          # the pull request ID
+          pr: ${{ github.event.number }}
+
+          # [required]
+          # the package name to be build and released
+          package-name: conda
+
+          # [required]
+          # the subdiretory, e.g. linux-64
+          subdir: ${{ matrix.subdir }}
+
+          # [required]
+          # the anaconda.org channel
+          anaconda-org-channel: conda-canary
+          # [required]
+          # the anaconda.org label to apply
+          anaconda-org-label: dev
+          # [required]
+          # the anaconda.org token to upload to the channel
+          anaconda-org-token: ${{ secrets.CANARY_ANACONDA_ORG_TOKEN }}
+
+          # [optional]
+          # the GitHub Personal Access Token to comment with
+          # comment-token: ${{ secrets.CANARY_ACTION_COMMENT_TOKEN }}
+          # [optional]
+          # the GitHub user account that comment with
+          # comment-author: conda-bot
+```
+a

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -121,9 +121,7 @@ runs:
         body-includes: '${{ steps.vars.outputs.status-header }}'
 
     - name: Leave comment after build
-      if: |
-        steps.after-build.output.comment-id != '' &&
-        inputs.comment-token != ''
+      if: inputs.comment-token != ''
       uses: peter-evans/create-or-update-comment@v1
       with:
         issue-number: ${{ inputs.pr }}

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -123,7 +123,7 @@ runs:
     - name: Leave comment after build
       if: |
         steps.after-build.output.comment-id != '' &&
-        inputs.comment-token != '' &&
+        inputs.comment-token != ''
       uses: peter-evans/create-or-update-comment@v1
       with:
         issue-number: ${{ inputs.pr }}

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -122,9 +122,9 @@ runs:
 
     - shell: bash -l {0}
       run: |
-        echo ${{ steps.after-build.outputs.comment-id }}
-        echo ${{ steps.after-build.outputs.comment-body }}
-        echo ${{ steps.after-build.outputs.comment-author }}
+        echo "${{ contains(steps.after-build.output.comment-body, steps.vars.outputs.status-tablehead) }}"
+        echo "${{ inputs.comment-token == '' }}"
+        echo "${{ steps.after-build.output.comment-id == '' }}"
 
     - name: Leave comment after build (append to status table)
       if: |

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -34,20 +34,13 @@ runs:
   steps:
     - uses: conda-incubator/setup-miniconda@v2
 
-    - name: Create URL to the run output
-      id: run-url
+    - name: Set output variables
+      id: vars
       shell: bash -l {0}
-      run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-
-    - name: Create status table head
-      id: status-tablehead
-      shell: bash -l {0}
-      run: echo "::set-output name=content::| Run | Outcome | User | Matrix | "
-
-    - name: Create status comment
-      id: status-comment
-      shell: bash -l {0}
-      run: echo "::set-output name=content::<!-- Status updates for PR following (do not delete) -->"
+      run: |
+        echo ::set-output name=run-url::"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        echo ::set-output name=status-tablehead::"| Run | Outcome | User | Matrix |"
+        echo ::set-output name=status-comment::"<!-- Status updates for PR following (do not delete) -->"
 
     - name: Find Comment with status
       uses: peter-evans/find-comment@v1
@@ -56,7 +49,7 @@ runs:
       with:
         issue-number: ${{ inputs.pr }}
         comment-author: "${{ inputs.comment-author }}"
-        body-includes: "${{ steps.status-comment.outputs.content }}"
+        body-includes: "${{ steps.vars.outputs.status-comment }}"
         direction: last
 
     - name: Create comment if there is no status update
@@ -69,7 +62,7 @@ runs:
         issue-number: ${{ inputs.pr }}
         body: |
           # ${{ inputs.comment-headline }}
-          > The workflow for building and uploading a canary release for ${{ inputs.package-name }} with the label `${{ inputs.anaconda-org-label }}` in channel `${{ inputs.anaconda-org-channel }}` [was started](${{ steps.run-url.outputs.run-url }}) in #${{ inputs.pr }} by @${{ github.actor }}!
+          > The workflow for building and uploading a canary release for ${{ inputs.package-name }} with the label `${{ inputs.anaconda-org-label }}` in channel `${{ inputs.anaconda-org-channel }}` [was started](${{ steps.vars.outputs.run-url }}) in #${{ inputs.pr }} by @${{ github.actor }}!
 
           Once it's done, use this command to try it out in a new conda environment:
 
@@ -78,7 +71,7 @@ runs:
           ```
 
           ------
-          ${{ steps.status-comment.outputs.content }}
+          ${{ steps.vars.outputs.status-comment }}
         reactions: 'rocket'
         token: ${{ inputs.comment-token }}
 
@@ -125,19 +118,19 @@ runs:
       with:
         issue-number: ${{ inputs.pr }}
         comment-author: "${{ inputs.comment-author }}"
-        body-includes: "${{ steps.status-comment.outputs.content }}"
+        body-includes: "${{ steps.vars.outputs.status-comment }}"
         direction: last
 
     - name: Leave comment after build (append to status table)
       if: |
         steps.after-build.output.comment-id != '' &&
         inputs.comment-token != '' &&
-        contains(steps.after-build.output.comment-body, steps.status-tablehead.outputs.content)
+        contains(steps.after-build.output.comment-body, steps.vars.outputs.status-tablehead)
       uses: peter-evans/create-or-update-comment@v1
       with:
         comment-id: ${{ steps.after-build.output.comment-id }}
         body: |
-          | [${{ github.run_id }}](${{ steps.run-url.outputs.run-url }}) | ${{ steps.build.outcome }} | @${{ github.actor }} | ${{ matrix }} |
+          | [${{ github.run_id }}](${{ steps.vars.outputs.run-url }}) | ${{ steps.build.outcome }} | @${{ github.actor }} | ${{ matrix }} |
         reactions: 'eyes'
         token: ${{ inputs.comment-token }}
 
@@ -145,13 +138,13 @@ runs:
       if: |
         steps.after-build.output.comment-id != '' &&
         inputs.comment-token != '' &&
-        !contains(steps.after-build.output.comment-body, steps.status-tablehead.outputs.content)
+        !contains(steps.after-build.output.comment-body, steps.vars.outputs.status-tablehead)
       uses: peter-evans/create-or-update-comment@v1
       with:
         comment-id: ${{ steps.after-build.output.comment-id }}
         body: |
-          ${{ steps.status-tablehead.outputs.content }}
+          ${{ steps.vars.outputs.status-tablehead }}
           |---|---|---|---|
-          | [${{ github.run_id }}](${{ steps.run-url.outputs.run-url }}) | ${{ steps.build.outcome }} | @${{ github.actor }} | ${{ matrix }} |
+          | [${{ github.run_id }}](${{ steps.vars.outputs.run-url }}) | ${{ steps.build.outcome }} | @${{ github.actor }} | ${{ matrix }} |
         reactions: 'eyes'
         token: ${{ inputs.comment-token }}

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -117,8 +117,8 @@ runs:
       id: after-build
       with:
         issue-number: ${{ inputs.pr }}
-        comment-author: "${{ inputs.comment-author }}"
-        body-includes: "${{ steps.vars.outputs.status-header }}"
+        comment-author: '${{ inputs.comment-author }}'
+        body-includes: '${{ steps.vars.outputs.status-header }}'
 
     - name: Leave comment after build
       if: |

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -122,9 +122,7 @@ runs:
         body-includes: "${{ steps.vars.outputs.status_comment }}"
 
     - name: Leave comment after build
-      if: |
-        inputs.comment-token != '' &&
-        steps.after_build.output.comment-id != ''
+      if: inputs.comment-token != ''
       uses: peter-evans/create-or-update-comment@v1
       with:
         comment-id: ${{ steps.after_build.output.comment-id }}

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -40,7 +40,7 @@ runs:
       run: |
         echo ::set-output name=run-url::"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
         echo ::set-output name=status-tablehead::"| Run | Outcome | User | Matrix |"
-        echo ::set-output name=status-comment::"<!-- Status updates for PR following (do not delete) -->"
+        echo ::set-output name=status-comment::"Status updates for PR following"
 
     - name: Find Comment with status
       uses: peter-evans/find-comment@v1
@@ -71,7 +71,7 @@ runs:
           ```
 
           ------
-          ${{ steps.vars.outputs.status-comment }}
+          <!-- ${{ steps.vars.outputs.status-comment }} -->
         reactions: 'rocket'
         token: ${{ inputs.comment-token }}
 

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -56,9 +56,7 @@ runs:
           ```
 
           ------
-          ### ${{ steps.vars.outputs.status-header }}
-          | Run | Outcome | User | Runner |
-          |---|---|---|---|
+
         GITHUB_TOKEN: ${{ inputs.comment-token }}
 
     - name: Build & upload package
@@ -98,10 +96,19 @@ runs:
         echo "conda install -c ${{ inputs.anaconda-org-channel }}/label/${{ inputs.anaconda-org-label }} ${{ inputs.package-name }}"
 
     - name: Leave comment after build
-      if: inputs.comment-token != ''
+      if: inputs.comment-token != '' && success()
       uses: marocchino/sticky-pull-request-comment@v2
       with:
         append: true
         message: |
-          | [${{ github.run_id }}](${{ steps.vars.outputs.run-url }}) | ${{ steps.build.outcome }} | @${{ github.actor }} | ${{ runner.os }} ${{ runner.arch }} |
+          - build [${{ github.run_id }}](${{ steps.vars.outputs.run-url }}) succeeded on ${{ runner.os }}/${{ runner.arch }}
+        GITHUB_TOKEN: ${{ inputs.comment-token }}
+
+    - name: Leave comment after build
+      if: inputs.comment-token != '' && failure()
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        append: true
+        message: |
+          - build [${{ github.run_id }}](${{ steps.vars.outputs.run-url }}) failed on ${{ runner.os }}/${{ runner.arch }}
         GITHUB_TOKEN: ${{ inputs.comment-token }}

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -11,8 +11,12 @@ inputs:
     description: 'Subdirectory'
     required: true
   comment-author:
-    description: 'Author for commenting build'
+    description: 'Author for build comment'
     required: false
+  comment-headline:
+    description: 'Headline for build comment'
+    required: false
+    default: 'Canary release status'
   comment-token:
     description: 'Token for commenting build'
     required: false
@@ -64,7 +68,7 @@ runs:
       with:
         issue-number: ${{ inputs.pr }}
         body: |
-          # Canary release status
+          # ${{ inputs.comment-headline }}
           > The workflow for building and uploading a canary release for ${{ inputs.package-name }} with the label `${{ inputs.anaconda-org-label }}` in channel `${{ inputs.anaconda-org-channel }}` [was started](${{ steps.run-url.outputs.run-url }}) in #${{ inputs.pr }} by @${{ github.actor }}!
 
           Once it's done, use this command to try it out in a new conda environment:

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -51,8 +51,8 @@ runs:
       id: before-build
       with:
         issue-number: ${{ inputs.pr }}
-        comment-author: ${{ inputs.comment-author }}
-        body-includes: ${{ steps.status-comment.outputs.content }}
+        comment-author: "${{ inputs.comment-author }}""
+        body-includes: "${{ steps.status-comment.outputs.content }}""
         direction: last
 
     - name: Create comment if there is no status update
@@ -120,8 +120,8 @@ runs:
       id: after-build
       with:
         issue-number: ${{ inputs.pr }}
-        comment-author: ${{ inputs.comment-author }}
-        body-includes: ${{ steps.status-comment.outputs.content }}
+        comment-author: "${{ inputs.comment-author }}"
+        body-includes: "${{ steps.status-comment.outputs.content }}"
         direction: last
 
     - name: Leave comment after build (append to status table)

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -125,7 +125,7 @@ runs:
       if: inputs.comment-token != ''
       uses: peter-evans/create-or-update-comment@v1
       with:
-        comment-id: ${{ steps.after_build.output.comment-id }}
+        comment-id: '${{ steps.after_build.output.comment-id }}'
         body: |
           | [${{ github.run_id }}](${{ steps.vars.outputs.run_url }}) | ${{ steps.build.outcome }} | @${{ github.actor }} | ${{ matrix }} |
         reactions: 'eyes'

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -1,0 +1,116 @@
+name: 'Canary releases'
+description: 'This builds and uploads canary releases of conda to the provided channel and label on anaconda.org.'
+inputs:
+  pr:
+    description: 'Pull request ID'
+    required: true
+  package-name:
+    description: 'Name of package on anaconda.org, needs to match build file name.'
+    required: true
+  subdir:
+    description: 'Subdirectory'
+    required: true
+  comment-author:
+    description: 'Author for commenting build'
+    required: false
+  comment-token:
+    description: 'Token for commenting build'
+    required: false
+  anaconda-org-channel:
+    description: 'Channel on anaconda.org'
+    required: true
+  anaconda-org-label:
+    description: 'Label to use on anaconda.org'
+    required: true
+  anaconda-org-token:
+    description: 'Upload token for anaconda.org'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - uses: conda-incubator/setup-miniconda@v2
+
+    - name: Create URL to the run output
+      id: vars
+      shell: bash -l {0}
+      run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+
+    - name: Find Comment
+      uses: peter-evans/find-comment@v1
+      if: inputs.comment-token != ''
+      id: find-comment
+      with:
+        issue-number: ${{ inputs.pr }}
+        comment-author: ${{ inputs.comment-author }}
+        body-includes: The canary build for
+        direction: last
+
+    - name: Create comment
+      uses: peter-evans/create-or-update-comment@v1
+      if: |
+        steps.find-comment.outputs.comment-id == '' &&
+        inputs.comment-token != ''
+      id: create-comment
+      with:
+        issue-number: ${{ inputs.pr }}
+        body: |
+          The canary build for ${{ inputs.package-name }} with the label `${{ inputs.anaconda-org-label }}` in channel `${{ inputs.anaconda-org-channel }}` [has started][1]!
+
+          Once it's done, use this command to try it out in an empty conda environment:
+
+          ```
+          conda install -c ${{ inputs.anaconda-org-channel }}/label/${{ inputs.anaconda-org-label }} ${{ inputs.package-name }}
+          ```
+
+          [1]: ${{ steps.vars.outputs.run-url }}
+        reactions: 'rocket'
+        token: ${{ inputs.comment-token }}
+
+    - name: Build & upload package
+      # make sure we don't run on forks
+      if: github.repository_owner == 'conda'
+      id: build
+      shell: bash -l {0}
+      run: |
+        echo "::group::Setting up environment"
+        set -euo pipefail
+        conda activate
+        conda update --yes --quiet conda
+        conda install --yes --quiet conda-build anaconda-client git
+        echo "::endgroup::"
+
+        echo "::group::Debugging information"
+        conda info
+        conda config --show-sources
+        conda list
+        echo "::endgroup::"
+
+        echo "::group::Building package"
+        conda build --croot=./pkgs conda.recipe
+        echo "::endgroup::"
+
+        echo "::group::Uploading package"
+        anaconda --token ${{ inputs.anaconda-org-token }} upload \
+          --force --register --no-progress \
+          --user ${{ inputs.anaconda-org-channel }} \
+          --label ${{ inputs.anaconda-org-label }} \
+          ./pkgs/${{ inputs.subdir }}/${{ inputs.package-name }}-*.tar.bz2
+        echo "Uploaded the following files:"
+        ls ./pkgs/${{ inputs.subdir }}/${{ inputs.package-name }}-*.tar.bz2 | cut -d/ -f3- | tr ' ' $'\n'
+        echo "::endgroup::"
+
+        echo "Use this command to try out the build:"
+        echo "conda install -c ${{ inputs.anaconda-org-channel }}/label/${{ inputs.anaconda-org-label }} ${{ inputs.package-name }}"
+
+    - name: Leave comment on failure
+      if: |
+        steps.build.outcome == 'failure' &&
+        inputs.comment-token != ''
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        body: |
+          The canary build failed! Please check the [workflow run][1] for errors.
+
+          [1]: ${{ steps.vars.outputs.run-url }}
+        reactions: 'eyes'
+        token: ${{ inputs.comment-token }}

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -39,7 +39,6 @@ runs:
       shell: bash -l {0}
       run: |
         echo ::set-output name=run-url::"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-        echo ::set-output name=status-tablehead::"| Run | Outcome | User | Matrix |"
         echo ::set-output name=status-comment::"Status updates for PR following"
 
     - name: Find Comment with status
@@ -72,6 +71,8 @@ runs:
 
           ------
           <!-- ${{ steps.vars.outputs.status-comment }} -->
+          | Run | Outcome | User | Matrix |
+          |---|---|---|---|
         reactions: 'rocket'
         token: ${{ inputs.comment-token }}
 
@@ -120,36 +121,14 @@ runs:
         comment-author: "${{ inputs.comment-author }}"
         body-includes: "${{ steps.vars.outputs.status-comment }}"
 
-    - shell: bash -l {0}
-      run: |
-        echo "${{ contains(steps.after-build.output.comment-body, steps.vars.outputs.status-tablehead) }}"
-        echo "${{ inputs.comment-token == '' }}"
-        echo "${{ steps.after-build.output.comment-id == '' }}"
-
-    - name: Leave comment after build (append to status table)
+    - name: Leave comment after build
       if: |
         steps.after-build.output.comment-id != '' &&
         inputs.comment-token != '' &&
-        contains(steps.after-build.output.comment-body, steps.vars.outputs.status-tablehead)
       uses: peter-evans/create-or-update-comment@v1
       with:
         comment-id: ${{ steps.after-build.output.comment-id }}
         body: |
-          | [${{ github.run_id }}](${{ steps.vars.outputs.run-url }}) | ${{ steps.build.outcome }} | @${{ github.actor }} | ${{ matrix }} |
-        reactions: 'eyes'
-        token: ${{ inputs.comment-token }}
-
-    - name: Leave comment after build (add status table)
-      if: |
-        steps.after-build.output.comment-id != '' &&
-        inputs.comment-token != '' &&
-        !contains(steps.after-build.output.comment-body, steps.vars.outputs.status-tablehead)
-      uses: peter-evans/create-or-update-comment@v1
-      with:
-        comment-id: ${{ steps.after-build.output.comment-id }}
-        body: |
-          ${{ steps.vars.outputs.status-tablehead }}
-          |---|---|---|---|
           | [${{ github.run_id }}](${{ steps.vars.outputs.run-url }}) | ${{ steps.build.outcome }} | @${{ github.actor }} | ${{ matrix }} |
         reactions: 'eyes'
         token: ${{ inputs.comment-token }}

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -65,7 +65,7 @@ runs:
         issue-number: ${{ inputs.pr }}
         body: |
           # Canary release status
-          > The workflow for building and uploading a canary release for ${{ inputs.package-name }} with the label `${{ inputs.anaconda-org-label }}` in channel `${{ inputs.anaconda-org-channel }}` [was started](${{ steps.run-url.outputs.run-url }}) in #${{ inputs.pr }} by ${{ github.actor }}!
+          > The workflow for building and uploading a canary release for ${{ inputs.package-name }} with the label `${{ inputs.anaconda-org-label }}` in channel `${{ inputs.anaconda-org-channel }}` [was started](${{ steps.run-url.outputs.run-url }}) in #${{ inputs.pr }} by @${{ github.actor }}!
 
           Once it's done, use this command to try it out in a new conda environment:
 

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -119,7 +119,12 @@ runs:
         issue-number: ${{ inputs.pr }}
         comment-author: "${{ inputs.comment-author }}"
         body-includes: "${{ steps.vars.outputs.status-comment }}"
-        direction: last
+
+    - shell: bash -l {0}
+      run: |
+        echo ${{ steps.after-build.outputs.comment-id }}
+        echo ${{ steps.after-build.outputs.comment-body }}
+        echo ${{ steps.after-build.outputs.comment-author }}
 
     - name: Leave comment after build (append to status table)
       if: |

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -1,18 +1,12 @@
 name: 'Canary releases'
 description: 'This builds and uploads canary releases of conda to the provided channel and label on anaconda.org.'
 inputs:
-  pr:
-    description: 'Pull request ID'
-    required: true
   package-name:
     description: 'Name of package on anaconda.org, needs to match build file name.'
     required: true
   subdir:
     description: 'Subdirectory'
     required: true
-  comment-author:
-    description: 'Author for build comment'
-    required: false
   comment-headline:
     description: 'Headline for build comment'
     required: false
@@ -47,7 +41,7 @@ runs:
       with:
         message: |
           # ${{ inputs.comment-headline }}
-          > The workflow for building and uploading a canary release for ${{ inputs.package-name }} with the label `${{ inputs.anaconda-org-label }}` in channel `${{ inputs.anaconda-org-channel }}` [was started](${{ steps.vars.outputs.run-url }}) in #${{ inputs.pr }} by @${{ github.actor }}!
+          > The workflow for building and uploading a canary release for ${{ inputs.package-name }} with the label `${{ inputs.anaconda-org-label }}` in channel `${{ inputs.anaconda-org-channel }}` [was started](${{ steps.vars.outputs.run-url }}) by @${{ github.actor }}!
 
           Once it's done, use this command to try it out in a new conda environment:
 

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -124,7 +124,7 @@ runs:
     - name: Leave comment after build
       if: |
         steps.after-build.output.comment-id != '' &&
-        inputs.comment-token != '' &&
+        inputs.comment-token != ''
       uses: peter-evans/create-or-update-comment@v1
       with:
         comment-id: ${{ steps.after-build.output.comment-id }}

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -31,9 +31,7 @@ runs:
     - name: Set output variables
       id: vars
       shell: bash -l {0}
-      run: |
-        echo ::set-output name=run-url::"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-        echo ::set-output name=status-header::"Status updates for builds"
+      run: echo ::set-output name=run-url::"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
     - name: Create comment if there is no status update
       uses: marocchino/sticky-pull-request-comment@v2
@@ -95,7 +93,7 @@ runs:
       with:
         append: true
         message: |
-          - build [${{ github.run_id }}](${{ steps.vars.outputs.run-url }}) succeeded on ${{ runner.os }}/${{ runner.arch }}
+          - build [${{ github.run_id }}](${{ steps.vars.outputs.run-url }}) succeeded on ${{ runner.os }} (${{ runner.arch }})
         GITHUB_TOKEN: ${{ inputs.comment-token }}
 
     - name: Leave comment after build
@@ -104,5 +102,5 @@ runs:
       with:
         append: true
         message: |
-          - build [${{ github.run_id }}](${{ steps.vars.outputs.run-url }}) failed on ${{ runner.os }}/${{ runner.arch }}
+          - build [${{ github.run_id }}](${{ steps.vars.outputs.run-url }}) failed on ${{ runner.os }} (${{ runner.arch }})
         GITHUB_TOKEN: ${{ inputs.comment-token }}

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -51,8 +51,8 @@ runs:
       id: before-build
       with:
         issue-number: ${{ inputs.pr }}
-        comment-author: "${{ inputs.comment-author }}""
-        body-includes: "${{ steps.status-comment.outputs.content }}""
+        comment-author: "${{ inputs.comment-author }}"
+        body-includes: "${{ steps.status-comment.outputs.content }}"
         direction: last
 
     - name: Create comment if there is no status update

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -38,29 +38,29 @@ runs:
       id: vars
       shell: bash -l {0}
       run: |
-        echo ::set-output name=run_url::"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-        echo ::set-output name=status_comment::"Status updates for builds"
+        echo ::set-output name=run-url::"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        echo ::set-output name=status-header::"Status updates for builds"
 
     - name: Find Comment with status
       uses: peter-evans/find-comment@v1
       if: inputs.comment-token != ''
-      id: before_build
+      id: before-build
       with:
         issue-number: ${{ inputs.pr }}
         comment-author: "${{ inputs.comment-author }}"
-        body-includes: "${{ steps.vars.outputs.status_comment }}"
+        body-includes: "${{ steps.vars.outputs.status-header }}"
         direction: last
 
     - name: Create comment if there is no status update
       uses: peter-evans/create-or-update-comment@v1
       if: |
         inputs.comment-token != '' &&
-        steps.before_build.outputs.comment-id == ''
+        steps.before-build.outputs.comment-id == ''
       with:
         issue-number: ${{ inputs.pr }}
         body: |
           # ${{ inputs.comment-headline }}
-          > The workflow for building and uploading a canary release for ${{ inputs.package-name }} with the label `${{ inputs.anaconda-org-label }}` in channel `${{ inputs.anaconda-org-channel }}` [was started](${{ steps.vars.outputs.run_url }}) in #${{ inputs.pr }} by @${{ github.actor }}!
+          > The workflow for building and uploading a canary release for ${{ inputs.package-name }} with the label `${{ inputs.anaconda-org-label }}` in channel `${{ inputs.anaconda-org-channel }}` [was started](${{ steps.vars.outputs.run-url }}) in #${{ inputs.pr }} by @${{ github.actor }}!
 
           Once it's done, use this command to try it out in a new conda environment:
 
@@ -69,8 +69,7 @@ runs:
           ```
 
           ------
-          ## ${{ steps.vars.outputs.status_comment }}
-
+          ### ${{ steps.vars.outputs.status-header }}
           | Run | Outcome | User | Matrix |
           |---|---|---|---|
         reactions: 'rocket'
@@ -115,18 +114,21 @@ runs:
     - name: Find Comment after build
       uses: peter-evans/find-comment@v1
       if: inputs.comment-token != ''
-      id: after_build
+      id: after-build
       with:
         issue-number: ${{ inputs.pr }}
         comment-author: "${{ inputs.comment-author }}"
-        body-includes: "${{ steps.vars.outputs.status_comment }}"
+        body-includes: "${{ steps.vars.outputs.status-header }}"
 
     - name: Leave comment after build
-      if: inputs.comment-token != ''
+      if: |
+        steps.after-build.output.comment-id != '' &&
+        inputs.comment-token != '' &&
       uses: peter-evans/create-or-update-comment@v1
       with:
-        comment-id: '${{ steps.after_build.output.comment-id }}'
+        issue-number: ${{ inputs.pr }}
+        comment-id: ${{ steps.after-build.output.comment-id }}
         body: |
-          | [${{ github.run_id }}](${{ steps.vars.outputs.run_url }}) | ${{ steps.build.outcome }} | @${{ github.actor }} | ${{ matrix }} |
+          | [${{ github.run_id }}](${{ steps.vars.outputs.run-url }}) | ${{ steps.build.outcome }} | @${{ github.actor }} | ${{ matrix }} |
         reactions: 'eyes'
         token: ${{ inputs.comment-token }}

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -38,30 +38,29 @@ runs:
       id: vars
       shell: bash -l {0}
       run: |
-        echo ::set-output name=run-url::"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-        echo ::set-output name=status-comment::"Status updates for PR following"
+        echo ::set-output name=run_url::"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        echo ::set-output name=status_comment::"Status updates for builds"
 
     - name: Find Comment with status
       uses: peter-evans/find-comment@v1
       if: inputs.comment-token != ''
-      id: before-build
+      id: before_build
       with:
         issue-number: ${{ inputs.pr }}
         comment-author: "${{ inputs.comment-author }}"
-        body-includes: "${{ steps.vars.outputs.status-comment }}"
+        body-includes: "${{ steps.vars.outputs.status_comment }}"
         direction: last
 
     - name: Create comment if there is no status update
       uses: peter-evans/create-or-update-comment@v1
       if: |
         inputs.comment-token != '' &&
-        steps.before-build.outputs.comment-id == ''
-      id: create-comment
+        steps.before_build.outputs.comment-id == ''
       with:
         issue-number: ${{ inputs.pr }}
         body: |
           # ${{ inputs.comment-headline }}
-          > The workflow for building and uploading a canary release for ${{ inputs.package-name }} with the label `${{ inputs.anaconda-org-label }}` in channel `${{ inputs.anaconda-org-channel }}` [was started](${{ steps.vars.outputs.run-url }}) in #${{ inputs.pr }} by @${{ github.actor }}!
+          > The workflow for building and uploading a canary release for ${{ inputs.package-name }} with the label `${{ inputs.anaconda-org-label }}` in channel `${{ inputs.anaconda-org-channel }}` [was started](${{ steps.vars.outputs.run_url }}) in #${{ inputs.pr }} by @${{ github.actor }}!
 
           Once it's done, use this command to try it out in a new conda environment:
 
@@ -70,7 +69,8 @@ runs:
           ```
 
           ------
-          <!-- ${{ steps.vars.outputs.status-comment }} -->
+          ## ${{ steps.vars.outputs.status_comment }}
+
           | Run | Outcome | User | Matrix |
           |---|---|---|---|
         reactions: 'rocket'
@@ -115,20 +115,20 @@ runs:
     - name: Find Comment after build
       uses: peter-evans/find-comment@v1
       if: inputs.comment-token != ''
-      id: after-build
+      id: after_build
       with:
         issue-number: ${{ inputs.pr }}
         comment-author: "${{ inputs.comment-author }}"
-        body-includes: "${{ steps.vars.outputs.status-comment }}"
+        body-includes: "${{ steps.vars.outputs.status_comment }}"
 
     - name: Leave comment after build
       if: |
-        steps.after-build.output.comment-id != '' &&
-        inputs.comment-token != ''
+        inputs.comment-token != '' &&
+        steps.after_build.output.comment-id != ''
       uses: peter-evans/create-or-update-comment@v1
       with:
-        comment-id: ${{ steps.after-build.output.comment-id }}
+        comment-id: ${{ steps.after_build.output.comment-id }}
         body: |
-          | [${{ github.run_id }}](${{ steps.vars.outputs.run-url }}) | ${{ steps.build.outcome }} | @${{ github.actor }} | ${{ matrix }} |
+          | [${{ github.run_id }}](${{ steps.vars.outputs.run_url }}) | ${{ steps.build.outcome }} | @${{ github.actor }} | ${{ matrix }} |
         reactions: 'eyes'
         token: ${{ inputs.comment-token }}

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -41,24 +41,11 @@ runs:
         echo ::set-output name=run-url::"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
         echo ::set-output name=status-header::"Status updates for builds"
 
-    - name: Find Comment with status
-      uses: peter-evans/find-comment@v1
-      if: inputs.comment-token != ''
-      id: before-build
-      with:
-        issue-number: ${{ inputs.pr }}
-        comment-author: "${{ inputs.comment-author }}"
-        body-includes: "${{ steps.vars.outputs.status-header }}"
-        direction: last
-
     - name: Create comment if there is no status update
-      uses: peter-evans/create-or-update-comment@v1
-      if: |
-        inputs.comment-token != '' &&
-        steps.before-build.outputs.comment-id == ''
+      uses: marocchino/sticky-pull-request-comment@v2
+      if: inputs.comment-token != ''
       with:
-        issue-number: ${{ inputs.pr }}
-        body: |
+        message: |
           # ${{ inputs.comment-headline }}
           > The workflow for building and uploading a canary release for ${{ inputs.package-name }} with the label `${{ inputs.anaconda-org-label }}` in channel `${{ inputs.anaconda-org-channel }}` [was started](${{ steps.vars.outputs.run-url }}) in #${{ inputs.pr }} by @${{ github.actor }}!
 
@@ -70,10 +57,9 @@ runs:
 
           ------
           ### ${{ steps.vars.outputs.status-header }}
-          | Run | Outcome | User | Matrix |
+          | Run | Outcome | User | Runner |
           |---|---|---|---|
-        reactions: 'rocket'
-        token: ${{ inputs.comment-token }}
+        GITHUB_TOKEN: ${{ inputs.comment-token }}
 
     - name: Build & upload package
       # make sure we don't run on forks
@@ -111,22 +97,11 @@ runs:
         echo "Use this command to try out the build:"
         echo "conda install -c ${{ inputs.anaconda-org-channel }}/label/${{ inputs.anaconda-org-label }} ${{ inputs.package-name }}"
 
-    - name: Find Comment after build
-      uses: peter-evans/find-comment@v1
-      if: inputs.comment-token != ''
-      id: after-build
-      with:
-        issue-number: ${{ inputs.pr }}
-        comment-author: '${{ inputs.comment-author }}'
-        body-includes: '${{ steps.vars.outputs.status-header }}'
-
     - name: Leave comment after build
       if: inputs.comment-token != ''
-      uses: peter-evans/create-or-update-comment@v1
+      uses: marocchino/sticky-pull-request-comment@v2
       with:
-        issue-number: ${{ inputs.pr }}
-        comment-id: ${{ steps.after-build.output.comment-id }}
-        body: |
-          | [${{ github.run_id }}](${{ steps.vars.outputs.run-url }}) | ${{ steps.build.outcome }} | @${{ github.actor }} | ${{ matrix }} |
-        reactions: 'eyes'
-        token: ${{ inputs.comment-token }}
+        append: true
+        message: |
+          | [${{ github.run_id }}](${{ steps.vars.outputs.run-url }}) | ${{ steps.build.outcome }} | @${{ github.actor }} | ${{ runner.os }} ${{ runner.arch }} |
+        GITHUB_TOKEN: ${{ inputs.comment-token }}

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -31,38 +31,50 @@ runs:
     - uses: conda-incubator/setup-miniconda@v2
 
     - name: Create URL to the run output
-      id: vars
+      id: run-url
       shell: bash -l {0}
       run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
 
-    - name: Find Comment
+    - name: Create status table head
+      id: status-tablehead
+      shell: bash -l {0}
+      run: echo "::set-output name=content::| Run | Outcome | User | Matrix | "
+
+    - name: Create status comment
+      id: status-comment
+      shell: bash -l {0}
+      run: echo "::set-output name=content::<!-- Status updates for PR following (do not delete) -->"
+
+    - name: Find Comment with status
       uses: peter-evans/find-comment@v1
       if: inputs.comment-token != ''
-      id: find-comment
+      id: before-build
       with:
         issue-number: ${{ inputs.pr }}
         comment-author: ${{ inputs.comment-author }}
-        body-includes: The canary build for
+        body-includes: ${{ steps.status-comment.outputs.content }}
         direction: last
 
-    - name: Create comment
+    - name: Create comment if there is no status update
       uses: peter-evans/create-or-update-comment@v1
       if: |
-        steps.find-comment.outputs.comment-id == '' &&
-        inputs.comment-token != ''
+        inputs.comment-token != '' &&
+        steps.before-build.outputs.comment-id == ''
       id: create-comment
       with:
         issue-number: ${{ inputs.pr }}
         body: |
-          The canary build for ${{ inputs.package-name }} with the label `${{ inputs.anaconda-org-label }}` in channel `${{ inputs.anaconda-org-channel }}` [has started][1]!
+          # Canary release status
+          > The workflow for building and uploading a canary release for ${{ inputs.package-name }} with the label `${{ inputs.anaconda-org-label }}` in channel `${{ inputs.anaconda-org-channel }}` [was started](${{ steps.run-url.outputs.run-url }}) in #${{ inputs.pr }} by ${{ github.actor }}!
 
-          Once it's done, use this command to try it out in an empty conda environment:
+          Once it's done, use this command to try it out in a new conda environment:
 
           ```
           conda install -c ${{ inputs.anaconda-org-channel }}/label/${{ inputs.anaconda-org-label }} ${{ inputs.package-name }}
           ```
 
-          [1]: ${{ steps.vars.outputs.run-url }}
+          ------
+          ${{ steps.status-comment.outputs.content }}
         reactions: 'rocket'
         token: ${{ inputs.comment-token }}
 
@@ -102,15 +114,40 @@ runs:
         echo "Use this command to try out the build:"
         echo "conda install -c ${{ inputs.anaconda-org-channel }}/label/${{ inputs.anaconda-org-label }} ${{ inputs.package-name }}"
 
-    - name: Leave comment on failure
+    - name: Find Comment after build
+      uses: peter-evans/find-comment@v1
+      if: inputs.comment-token != ''
+      id: after-build
+      with:
+        issue-number: ${{ inputs.pr }}
+        comment-author: ${{ inputs.comment-author }}
+        body-includes: ${{ steps.status-comment.outputs.content }}
+        direction: last
+
+    - name: Leave comment after build (append to status table)
       if: |
-        steps.build.outcome == 'failure' &&
-        inputs.comment-token != ''
+        steps.after-build.output.comment-id != '' &&
+        inputs.comment-token != '' &&
+        contains(steps.after-build.output.comment-body, steps.status-tablehead.outputs.content)
       uses: peter-evans/create-or-update-comment@v1
       with:
+        comment-id: ${{ steps.after-build.output.comment-id }}
         body: |
-          The canary build failed! Please check the [workflow run][1] for errors.
+          | [${{ github.run_id }}](${{ steps.run-url.outputs.run-url }}) | ${{ steps.build.outcome }} | @${{ github.actor }} | ${{ matrix }} |
+        reactions: 'eyes'
+        token: ${{ inputs.comment-token }}
 
-          [1]: ${{ steps.vars.outputs.run-url }}
+    - name: Leave comment after build (add status table)
+      if: |
+        steps.after-build.output.comment-id != '' &&
+        inputs.comment-token != '' &&
+        !contains(steps.after-build.output.comment-body, steps.status-tablehead.outputs.content)
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        comment-id: ${{ steps.after-build.output.comment-id }}
+        body: |
+          ${{ steps.status-tablehead.outputs.content }}
+          |---|---|---|---|
+          | [${{ github.run_id }}](${{ steps.run-url.outputs.run-url }}) | ${{ steps.build.outcome }} | @${{ github.actor }} | ${{ matrix }} |
         reactions: 'eyes'
         token: ${{ inputs.comment-token }}


### PR DESCRIPTION
A new GitHub action to be used by projects in the conda GitHub organization to build and upload canary releases to anaconda.org.

Originally was written for https://github.com/conda/conda/pull/11135.