### PR TITLE
Catch async exceptions

### DIFF
--- a/.github/workflows/issue-in-project.yml
+++ b/.github/workflows/issue-in-project.yml
@@ -17,6 +17,7 @@ jobs:
           # checkout repo where the branch is coming from (i.e. forks) that
           # way we commit build changes to the correct repo/branch
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
       - uses: actions/setup-node@v2
         with:
           node-version: 16

--- a/.github/workflows/issue-in-project.yml
+++ b/.github/workflows/issue-in-project.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          token: ${{ secrets.PUSH_CHANGES_TOKEN }}
           # checkout repo where the branch is coming from (i.e. forks) that
           # way we commit build changes to the correct repo/branch
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -23,9 +24,10 @@ jobs:
           node-version: 16
       - run: npm install
       - run: npm run build
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Rebuild issue-in-project
-          commit_user_name: Conda Bot
-          commit_user_email: conda-bot@users.noreply.github.com
-          commit_author: Conda Bot <conda-bot@users.noreply.github.com>
+      - run: git add --all
+      - run: >-
+          git
+          -c user.name="Conda Bot"
+          -c user.email="conda-bot@users.noreply.github.com"
+          commit -m "Rebuild issue-in-project"
+      - run: git push

--- a/.github/workflows/user-in-team.yml
+++ b/.github/workflows/user-in-team.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          token: ${{ secrets.PUSH_CHANGES_TOKEN }}
           # checkout repo where the branch is coming from (i.e. forks) that
           # way we commit build changes to the correct repo/branch
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -23,9 +24,10 @@ jobs:
           node-version: 16
       - run: npm install
       - run: npm run build
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Rebuild user-in-team
-          commit_user_name: Conda Bot
-          commit_user_email: conda-bot@users.noreply.github.com
-          commit_author: Conda Bot <conda-bot@users.noreply.github.com>
+      - run: git add --all
+      - run: >-
+          git
+          -c user.name="Conda Bot"
+          -c user.email="conda-bot@users.noreply.github.com"
+          commit -m "Rebuild user-in-team"
+      - run: git push

--- a/.github/workflows/user-in-team.yml
+++ b/.github/workflows/user-in-team.yml
@@ -17,6 +17,7 @@ jobs:
           # checkout repo where the branch is coming from (i.e. forks) that
           # way we commit build changes to the correct repo/branch
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
       - uses: actions/setup-node@v2
         with:
           node-version: 16

--- a/issue-in-project/src/cli.ts
+++ b/issue-in-project/src/cli.ts
@@ -36,15 +36,13 @@ export async function cli(
       console.log(await issueInProject(owner, project, issue))
     })
 
-  if (argv) program.parseAsync(argv, { from: 'user' })
-  else program.parseAsync()
+  if (argv) await program.parseAsync(argv, { from: 'user' })
+  else await program.parseAsync()
 }
 
 if (require.main === module) {
-  try {
-    cli()
-  } catch (err) {
+  cli().catch(err => {
     if (err instanceof Error) setFailed(err)
     else throw err
-  }
+  })
 }

--- a/issue-in-project/src/gha.ts
+++ b/issue-in-project/src/gha.ts
@@ -30,10 +30,8 @@ export async function gha(): Promise<void> {
 }
 
 if (require.main === module) {
-  try {
-    gha()
-  } catch (err) {
+  gha().catch(err => {
     if (err instanceof Error) setFailed(err)
     else throw err
-  }
+  })
 }

--- a/issue-in-project/src/index.ts
+++ b/issue-in-project/src/index.ts
@@ -7,8 +7,8 @@ export * as utils from '@src/utils'
 
 if (require.main === module) {
   // make a guess as to whether running as CLI tool or GitHub Action
-  const func=process.argv.length > 2 ? cli : gha
-  func().catch(err=>{
+  const func = process.argv.length > 2 ? cli : gha
+  func().catch(err => {
     if (err instanceof Error) setFailed(err)
     else throw err
   })

--- a/issue-in-project/src/index.ts
+++ b/issue-in-project/src/index.ts
@@ -6,11 +6,10 @@ export * as api from '@src/api'
 export * as utils from '@src/utils'
 
 if (require.main === module) {
-  try {
-    // make a guess as to whether running as CLI tool or GitHub Action
-    process.argv.length > 2 ? cli() : gha()
-  } catch (err) {
+  // make a guess as to whether running as CLI tool or GitHub Action
+  const func = process.argv.length > 2 ? cli : gha
+  func().catch(err => {
     if (err instanceof Error) setFailed(err)
     else throw err
-  }
+  })
 }

--- a/issue-in-project/src/index.ts
+++ b/issue-in-project/src/index.ts
@@ -7,8 +7,8 @@ export * as utils from '@src/utils'
 
 if (require.main === module) {
   // make a guess as to whether running as CLI tool or GitHub Action
-  const func = process.argv.length > 2 ? cli : gha
-  func().catch(err => {
+  const func=process.argv.length > 2 ? cli : gha
+  func().catch(err=>{
     if (err instanceof Error) setFailed(err)
     else throw err
   })

--- a/read-yaml/action.yml
+++ b/read-yaml/action.yml
@@ -27,23 +27,38 @@ runs:
         script: |
           const yaml = require('js-yaml');
 
-          const path = core.getInput('path', { required: true });
-          const scopes = yaml.load(core.getInput('scopes') || ''));
-          const url = `/repos/${context.repo.owner}/${context.repo.repo}/contents/${path}`;
+          async function read_yaml() {
+            const path = core.getInput('path', { required: true });
+            const scopes = yaml.load(core.getInput('scopes') || '{}');
+            const url = `/repos/${context.repo.owner}/${context.repo.repo}/contents/${path}`;
 
-          const resp = await github.request(`GET ${url}`);
-          let data = yaml.load(
-            Buffer.from(
-              resp["data"]["content"],
-              resp["data"]["encoding"]
-            ).toString('utf-8')
-          );
-          for (const scope of scopes) {
-            let value = data;
-            for (const key of scopes[scope].split('.'))
-              value = value instanceof Array ? value[parseInt(key)] : value[key];
-            core.setOutput(scope, value);
+            try {
+              const resp = await github.request(`GET ${url}`, {ref: context.sha});
+            } catch (err) {
+              throw new Error(`Failed to fetch ${path} (${err.message})`);
+            }
+            let data = yaml.load(
+              Buffer.from(
+                resp["data"]["content"],
+                resp["data"]["encoding"]
+              ).toString('utf-8')
+            );
+            for (const scope in scopes) {
+              let value = data;
+              try {
+                for (const key of scopes[scope].split('.'))
+                  value = value instanceof Array ? value[parseInt(key)] : value[key];
+              } catch (err) {
+                throw new Error(`Failed to read ${scopes[scope]} (${err.message})`);
+              }
+              core.setOutput(scope, value);
+            }
           }
+
+          read_yaml().catch(err => {
+            if (err instanceof Error) core.setFailed(err);
+            else throw err;
+          });
 branding:
   icon: book-open
   color: green

--- a/user-in-team/src/cli.ts
+++ b/user-in-team/src/cli.ts
@@ -31,15 +31,13 @@ export async function cli(
       console.log(await userInTeam(org, team, user))
     })
 
-  if (argv) program.parseAsync(argv, { from: 'user' })
-  else program.parseAsync()
+  if (argv) await program.parseAsync(argv, { from: 'user' })
+  else await program.parseAsync()
 }
 
 if (require.main === module) {
-  try {
-    cli()
-  } catch (err) {
-    if (err instanceof Error) setFailed(err.message)
+  cli().catch(err => {
+    if (err instanceof Error) setFailed(err)
     else throw err
-  }
+  })
 }

--- a/user-in-team/src/gha.ts
+++ b/user-in-team/src/gha.ts
@@ -25,10 +25,8 @@ export async function gha(): Promise<void> {
 }
 
 if (require.main === module) {
-  try {
-    gha()
-  } catch (err) {
-    if (err instanceof Error) setFailed(err.message)
+  gha().catch(err => {
+    if (err instanceof Error) setFailed(err)
     else throw err
-  }
+  })
 }

--- a/user-in-team/src/index.ts
+++ b/user-in-team/src/index.ts
@@ -6,11 +6,10 @@ export * as api from '@src/api'
 export * as utils from '@src/utils'
 
 if (require.main === module) {
-  try {
-    // make a guess as to whether running as CLI tool or GitHub Action
-    process.argv.length > 2 ? cli() : gha()
-  } catch (err) {
+  // make a guess as to whether running as CLI tool or GitHub Action
+  const func = process.argv.length > 2 ? cli : gha
+  func().catch(err => {
     if (err instanceof Error) setFailed(err)
     else throw err
-  }
+  })
 }


### PR DESCRIPTION
Previously we weren't actually catching the top-level async exceptions. We were doing this:

```js
try {
    cli()
} catch (err) {
    if (err instanceof Error) setFailed(err)
    else throw err
}
```

But instead needed this:

```js
cli().catch(err => {
    if (err instanceof Error) setFailed(err)
    else throw err
})
```

Nothing has functionally changed here we just catch the errors in a cleaner manner.