### PR TITLE
Catch async exceptions

### DIFF
--- a/.github/workflows/issue-in-project.yml
+++ b/.github/workflows/issue-in-project.yml
@@ -13,10 +13,6 @@ jobs:
         working-directory: issue-in-project
     steps:
       - uses: actions/checkout@v2
-        with:
-          # checkout repo where the branch is coming from (i.e. forks) that
-          # way we commit build changes to the correct repo/branch
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - uses: actions/setup-node@v2
         with:
           node-version: 16

--- a/.github/workflows/user-in-team.yml
+++ b/.github/workflows/user-in-team.yml
@@ -13,10 +13,6 @@ jobs:
         working-directory: user-in-team
     steps:
       - uses: actions/checkout@v2
-        with:
-          # checkout repo where the branch is coming from (i.e. forks) that
-          # way we commit build changes to the correct repo/branch
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - uses: actions/setup-node@v2
         with:
           node-version: 16

--- a/issue-in-project/dist/index.js
+++ b/issue-in-project/dist/index.js
@@ -8397,9 +8397,9 @@ async function cli(argv, exceptionError) {
         console.log(await (0, api_1.issueInProject)(owner, project, issue));
     });
     if (argv)
-        program.parseAsync(argv, { from: 'user' });
+        await program.parseAsync(argv, { from: 'user' });
     else
-        program.parseAsync();
+        await program.parseAsync();
 }
 exports.cli = cli;
 if (false) {}
@@ -8477,15 +8477,12 @@ Object.defineProperty(exports, "gha", ({ enumerable: true, get: function () { re
 exports.api = __importStar(__nccwpck_require__(8229));
 exports.utils = __importStar(__nccwpck_require__(1314));
 if (require.main === require.cache[eval('__filename')]) {
-    try {
-        process.argv.length > 2 ? (0, cli_1.cli)() : (0, gha_1.gha)();
-    }
-    catch (err) {
+    (process.argv.length > 2 ? (0, cli_1.cli)() : (0, gha_1.gha)()).catch(err => {
         if (err instanceof Error)
             (0, core_1.setFailed)(err);
         else
             throw err;
-    }
+    });
 }
 
 

--- a/issue-in-project/src/cli.ts
+++ b/issue-in-project/src/cli.ts
@@ -36,15 +36,13 @@ export async function cli(
       console.log(await issueInProject(owner, project, issue))
     })
 
-  if (argv) program.parseAsync(argv, { from: 'user' })
-  else program.parseAsync()
+  if (argv) await program.parseAsync(argv, { from: 'user' })
+  else await program.parseAsync()
 }
 
 if (require.main === module) {
-  try {
-    cli()
-  } catch (err) {
+  cli().catch(err => {
     if (err instanceof Error) setFailed(err)
     else throw err
-  }
+  })
 }

--- a/issue-in-project/src/gha.ts
+++ b/issue-in-project/src/gha.ts
@@ -30,10 +30,8 @@ export async function gha(): Promise<void> {
 }
 
 if (require.main === module) {
-  try {
-    gha()
-  } catch (err) {
+  gha().catch(err => {
     if (err instanceof Error) setFailed(err)
     else throw err
-  }
+  })
 }

--- a/issue-in-project/src/index.ts
+++ b/issue-in-project/src/index.ts
@@ -7,7 +7,7 @@ export * as utils from '@src/utils'
 
 if (require.main === module) {
   // make a guess as to whether running as CLI tool or GitHub Action
-  (process.argv.length > 2 ? cli() : gha()).catch(err => {
+  ;(process.argv.length > 2 ? cli() : gha()).catch(err => {
     if (err instanceof Error) setFailed(err)
     else throw err
   })

--- a/issue-in-project/src/index.ts
+++ b/issue-in-project/src/index.ts
@@ -6,11 +6,9 @@ export * as api from '@src/api'
 export * as utils from '@src/utils'
 
 if (require.main === module) {
-  try {
-    // make a guess as to whether running as CLI tool or GitHub Action
-    process.argv.length > 2 ? cli() : gha()
-  } catch (err) {
+  // make a guess as to whether running as CLI tool or GitHub Action
+  (process.argv.length > 2 ? cli() : gha()).catch(err => {
     if (err instanceof Error) setFailed(err)
     else throw err
-  }
+  })
 }

--- a/user-in-team/dist/index.js
+++ b/user-in-team/dist/index.js
@@ -8356,9 +8356,9 @@ async function cli(argv, exceptionError) {
         console.log(await (0, api_1.userInTeam)(org, team, user));
     });
     if (argv)
-        program.parseAsync(argv, { from: 'user' });
+        await program.parseAsync(argv, { from: 'user' });
     else
-        program.parseAsync();
+        await program.parseAsync();
 }
 exports.cli = cli;
 if (false) {}
@@ -8431,15 +8431,12 @@ Object.defineProperty(exports, "gha", ({ enumerable: true, get: function () { re
 exports.api = __importStar(__nccwpck_require__(8229));
 exports.utils = __importStar(__nccwpck_require__(1314));
 if (require.main === require.cache[eval('__filename')]) {
-    try {
-        process.argv.length > 2 ? (0, cli_1.cli)() : (0, gha_1.gha)();
-    }
-    catch (err) {
+    (process.argv.length > 2 ? (0, cli_1.cli)() : (0, gha_1.gha)()).catch(err => {
         if (err instanceof Error)
             (0, core_1.setFailed)(err);
         else
             throw err;
-    }
+    });
 }
 
 

--- a/user-in-team/src/cli.ts
+++ b/user-in-team/src/cli.ts
@@ -31,15 +31,13 @@ export async function cli(
       console.log(await userInTeam(org, team, user))
     })
 
-  if (argv) program.parseAsync(argv, { from: 'user' })
-  else program.parseAsync()
+  if (argv) await program.parseAsync(argv, { from: 'user' })
+  else await program.parseAsync()
 }
 
 if (require.main === module) {
-  try {
-    cli()
-  } catch (err) {
-    if (err instanceof Error) setFailed(err.message)
+  cli().catch(err => {
+    if (err instanceof Error) setFailed(err)
     else throw err
-  }
+  })
 }

--- a/user-in-team/src/gha.ts
+++ b/user-in-team/src/gha.ts
@@ -25,10 +25,8 @@ export async function gha(): Promise<void> {
 }
 
 if (require.main === module) {
-  try {
-    gha()
-  } catch (err) {
-    if (err instanceof Error) setFailed(err.message)
+  gha().catch(err => {
+    if (err instanceof Error) setFailed(err)
     else throw err
-  }
+  })
 }

--- a/user-in-team/src/index.ts
+++ b/user-in-team/src/index.ts
@@ -7,7 +7,7 @@ export * as utils from '@src/utils'
 
 if (require.main === module) {
   // make a guess as to whether running as CLI tool or GitHub Action
-  (process.argv.length > 2 ? cli() : gha()).catch(err => {
+  ;(process.argv.length > 2 ? cli() : gha()).catch(err => {
     if (err instanceof Error) setFailed(err)
     else throw err
   })

--- a/user-in-team/src/index.ts
+++ b/user-in-team/src/index.ts
@@ -6,11 +6,9 @@ export * as api from '@src/api'
 export * as utils from '@src/utils'
 
 if (require.main === module) {
-  try {
-    // make a guess as to whether running as CLI tool or GitHub Action
-    process.argv.length > 2 ? cli() : gha()
-  } catch (err) {
+  // make a guess as to whether running as CLI tool or GitHub Action
+  (process.argv.length > 2 ? cli() : gha()).catch(err => {
     if (err instanceof Error) setFailed(err)
     else throw err
-  }
+  })
 }


### PR DESCRIPTION
Previously we weren't actually catching the top-level async exceptions. We were doing this:

```js
try {
    cli()
} catch (err) {
    if (err instanceof Error) setFailed(err)
    else throw err
}
```

But instead needed this:

```js
cli().catch(err => {
    if (err instanceof Error) setFailed(err)
    else throw err
})
```

Nothing has functionally changed here we just catch the errors in a cleaner manner.