### PR TITLE
Canary-release fix for broken git on Windows

### DIFF
--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -63,6 +63,9 @@ runs:
         conda activate
         conda update --yes --quiet conda
         conda install --yes --quiet conda-build anaconda-client
+        # git needs to be installed after conda-build
+        # see https://github.com/conda/conda/issues/11758
+        # see https://github.com/conda/actions/pull/47
         conda install --yes --quiet git
         echo "::endgroup::"
 

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -62,7 +62,7 @@ runs:
         set -euo pipefail
         conda activate
         conda update --yes --quiet conda
-        conda install --yes --quiet conda-build anaconda-client git
+        conda install --yes --quiet --force-reinstall conda-build anaconda-client git
         echo "::endgroup::"
 
         echo "::group::Debugging information"

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -62,8 +62,8 @@ runs:
         set -euo pipefail
         conda activate
         conda update --yes --quiet conda
-        conda install --yes --quiet conda-build anaconda-client git
-        conda install --yes --quiet --force-reinstall git
+        conda install --yes --quiet conda-build anaconda-client
+        conda install --yes --quiet git
         echo "::endgroup::"
 
         echo "::group::Debugging information"

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -62,7 +62,8 @@ runs:
         set -euo pipefail
         conda activate
         conda update --yes --quiet conda
-        conda install --yes --quiet --force-reinstall conda-build anaconda-client git
+        conda install --yes --quiet conda-build anaconda-client git
+        conda install --yes --quiet --force-reinstall git
         echo "::endgroup::"
 
         echo "::group::Debugging information"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

It turns out that a recent update to conda's dependencies (adding `m2-patch`) results in a broken `git`. To fix this we need to run `conda install git` _after_ `conda install conda-build`.

Xref https://github.com/conda/conda/issues/11758

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] ~Add / update necessary tests?~
- [x] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
