### PR TITLE
Allow custom conda recipe folder used in canary-release

### DIFF
--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -26,6 +26,10 @@ inputs:
   conda-build-arguments:
     description: 'Command line arguments for conda-build, inserted before recipe path with no processing.'
     required: false
+  conda-build-path:
+    description: 'The path to the conda recipe passed to conda-build.'
+    required: false
+    default: recipe
 runs:
   using: "composite"
   steps:
@@ -76,7 +80,7 @@ runs:
         echo "::endgroup::"
 
         echo "::group::Building package"
-        conda build --croot=./pkgs ${{ inputs.conda-build-arguments }} conda.recipe
+        conda build --croot=./pkgs ${{ inputs.conda-build-arguments }} ${{ inputs.conda-build-path }}
         echo "::endgroup::"
 
         echo "::group::Uploading package"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Conda recipes are traditionally stored in a `recipe/` directory (not `conda.recipe/`) so let's do the same.

xref: https://github.com/conda/conda/issues/11701

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] ~Add / update necessary tests?~
- [x] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
