### PR TITLE
update github-status-action to v1.1.6

### DIFF
--- a/check-cla/action.yml
+++ b/check-cla/action.yml
@@ -36,7 +36,7 @@ runs:
           core.setOutput('hasLabel', hasLabel);
 
     - name: Set commit status with pending
-      uses: Sibz/github-status-action@v1
+      uses: Sibz/github-status-action@v1.1.6
       with:
         authToken: ${{ inputs.token }}
         context: "CLA check"
@@ -116,7 +116,7 @@ runs:
 
     - name: Set commit status to error
       if: steps.contributors.outputs.hasSigned == 'false'
-      uses: Sibz/github-status-action@v1
+      uses: Sibz/github-status-action@v1.1.6
       with:
         authToken: ${{ inputs.token }}
         context: CLA check
@@ -127,7 +127,7 @@ runs:
 
     - name: Set commit status to success
       if: steps.contributors.outputs.hasSigned == 'true'
-      uses: Sibz/github-status-action@v1
+      uses: Sibz/github-status-action@v1.1.6
       with:
         authToken: ${{ inputs.token }}
         context: CLA check


### PR DESCRIPTION
GitHub complains that this action uses node 12 instead of a newer version of node. This doesn't change that, but it does update to the latest version to grab their (security) dependency updates.