### PR TITLE
Use dholth status action

### DIFF
--- a/check-cla/action.yml
+++ b/check-cla/action.yml
@@ -36,7 +36,7 @@ runs:
           core.setOutput('hasLabel', hasLabel);
 
     - name: Set commit status with pending
-      uses: Sibz/github-status-action@v1
+      uses: Sibz/github-status-action@v1.1.6
       with:
         authToken: ${{ inputs.token }}
         context: "CLA check"
@@ -116,7 +116,7 @@ runs:
 
     - name: Set commit status to error
       if: steps.contributors.outputs.hasSigned == 'false'
-      uses: Sibz/github-status-action@v1
+      uses: Sibz/github-status-action@v1.1.6
       with:
         authToken: ${{ inputs.token }}
         context: CLA check
@@ -127,7 +127,7 @@ runs:
 
     - name: Set commit status to success
       if: steps.contributors.outputs.hasSigned == 'true'
-      uses: Sibz/github-status-action@v1
+      uses: Sibz/github-status-action@v1.1.6
       with:
         authToken: ${{ inputs.token }}
         context: CLA check

--- a/check-cla/action.yml
+++ b/check-cla/action.yml
@@ -36,7 +36,7 @@ runs:
           core.setOutput('hasLabel', hasLabel);
 
     - name: Set commit status with pending
-      uses: Sibz/github-status-action@v1.1.6
+      uses: dholth/github-status-action@runs-using-node16
       with:
         authToken: ${{ inputs.token }}
         context: "CLA check"
@@ -116,7 +116,7 @@ runs:
 
     - name: Set commit status to error
       if: steps.contributors.outputs.hasSigned == 'false'
-      uses: Sibz/github-status-action@v1.1.6
+      uses: dholth/github-status-action@runs-using-node16
       with:
         authToken: ${{ inputs.token }}
         context: CLA check
@@ -127,7 +127,7 @@ runs:
 
     - name: Set commit status to success
       if: steps.contributors.outputs.hasSigned == 'true'
-      uses: Sibz/github-status-action@v1.1.6
+      uses: dholth/github-status-action@runs-using-node16
       with:
         authToken: ${{ inputs.token }}
         context: CLA check


### PR DESCRIPTION
### Description

Uses forked status-action to in turn use updated Node 16 runtime

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
