### PR TITLE
CLA sort is case insensitive

### DIFF
--- a/check-cla/action.yml
+++ b/check-cla/action.yml
@@ -133,7 +133,7 @@ runs:
         path = Path("${{ inputs.cla_path }}")
         signees = json.loads(path.read_text())
         signees["contributors"].append("${{ steps.metadata.outputs.contributor }}")
-        signees["contributors"].sort()
+        signees["contributors"].sort(key=str.lower)
         path.write_text(json.dumps(signees, indent=2))
 
     # if unsigned, create PR


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The new CLA bot workflow works great however it's initially sorting the CLA config file incorrectly to then have pre-commit reorder the file again:

initially: https://github.com/conda/infrastructure/pull/767/commits/3c544090df04043b6a0fd38a0de93556f46321cf
pre-commit: https://github.com/conda/infrastructure/pull/767/commits/b5398f876d996a47c2acdcf9817c77e26ba7e83a
net: https://github.com/conda/infrastructure/pull/767/files

See pre-commit hook using [`sorted(set(value), key=str.lower)`](https://github.com/conda/infrastructure/blob/bf626cba27bca1b04d6bcdc64f4cb1d2b3b96572/sort_json.py#L18)

Resolves #105 

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
