### PR TITLE
Replace `ls | cut` with `basename -a`

### DIFF
--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -95,7 +95,7 @@ runs:
           --label="${{ inputs.anaconda-org-label }}" \
           ./pkgs/${{ inputs.subdir }}/${{ inputs.package-name }}-*.tar.bz2
         echo "Uploaded the following files:"
-        ls ./pkgs/${{ inputs.subdir }}/${{ inputs.package-name }}-*.tar.bz2 | cut -d/ -f3- | tr ' ' $'\n'
+        basename -a ./pkgs/${{ inputs.subdir }}/${{ inputs.package-name }}-*.tar.bz2
         echo "::endgroup::"
 
         echo "Use this command to try out the build:"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The windows runs of the canary-release workflow keeps getting the following [error](https://github.com/conda/conda/actions/runs/5525653465/jobs/10082231596#step:5:4968):

```
Uploaded the following files:
/usr/bin/cut: -: Broken pipe
Error: Process completed with exit code 1.
```

No idea why since this worked previously 🤷🏼‍♂️. This is an attempt to fix the issue by using standard GNU `basename` features. See https://superuser.com/a/1178917 for more.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
