### PR TITLE
Include a trailing newline in CLA PR

### DIFF
--- a/check-cla/action.yml
+++ b/check-cla/action.yml
@@ -134,7 +134,7 @@ runs:
         signees = json.loads(path.read_text())
         signees["contributors"].append("${{ steps.metadata.outputs.contributor }}")
         signees["contributors"].sort(key=str.lower)
-        path.write_text(json.dumps(signees, indent=2))
+        path.write_text(json.dumps(signees, indent=2) + "\n")
 
     # if unsigned, create PR
     - name: Create PR with new CLA signee


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The pre-commit check done in conda/infrastructure [ensures a trailing newline on .clabot file](https://github.com/conda/infrastructure/blob/76d22d942f9c2c3ad3abbf2a8303802f5b82ed12/sort_json.py#L30). We should do the same in the action itself.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
