### PR TITLE
Build canary packages in Linux anaconda-pkg-build container

### DIFF
--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -57,6 +57,10 @@ runs:
 
         GITHUB_TOKEN: ${{ inputs.comment-token }}
 
+    - name: Set up QEMU
+      if: runner.os == 'Linux'
+      uses: docker/setup-qemu-action@v3
+
     - name: Build & upload package
       # make sure we don't run on forks
       if: github.repository_owner == 'conda' || github.repository_owner == 'conda-incubator'
@@ -81,7 +85,28 @@ runs:
         echo "::endgroup::"
 
         echo "::group::Building package"
-        conda build --croot=./pkgs ${{ inputs.conda-build-arguments }} ${{ inputs.conda-build-path }}
+        if [[ ${{ inputs.subdir }} == "linux-"* ]]; then
+          # building in the anaconda-pkg-build container
+          # source https://github.com/ContinuumIO/docker-images/blob/main/anaconda-pkg-build/linux/Dockerfile
+          platform="${{ inputs.subdir }}"
+          platform="${platform/linux-64/linux-amd64}"
+          platform="${platform/\-/\/}"
+          set -x
+          docker run \
+            --rm \
+            --platform "$platform" \
+            -e _CONDA_BUILD_ISOLATED_ACTIVATION \
+            -v $(pwd):/build_root \
+            -w /build_root \
+            public.ecr.aws/y0o4y9o3/anaconda-pkg-build:latest \
+            /bin/bash -c "\
+              conda install -y git && \
+              conda build --croot=/build_root/pkgs ${{ inputs.conda-build-arguments }} /build_root/${{ inputs.conda-build-path }}\
+            "
+          set +x
+        else
+          conda build --croot=./pkgs ${{ inputs.conda-build-arguments }} ${{ inputs.conda-build-path }}
+        fi
         echo "::endgroup::"
 
         echo "::group::Uploading package"


### PR DESCRIPTION
This unlocks canary builds on linux-{aarch64, ppc64le, s390x} via the multi-arch anaconda-pkg-build container.

Tested here https://github.com/conda/conda/pull/13636

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
