### PR TITLE
Install miniconda on osx-arm64

### DIFF
--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -37,7 +37,6 @@ runs:
       with:
         # conda not preinstalled in arm64 runners
         miniconda-version: ${{ (runner.os == 'macOS' && runner.arch == 'ARM64') && 'latest' || null }}
-        conda-build-version: latest
         auto-update-conda: true
 
     - name: Set output variables
@@ -69,11 +68,11 @@ runs:
       run: |
         echo "::group::Setting up environment"
         set -euo pipefail
-        conda activate
+        conda install --yes --quiet conda-build anaconda-client
         # git needs to be installed after conda-build
         # see https://github.com/conda/conda/issues/11758
         # see https://github.com/conda/actions/pull/47
-        conda install --yes --quiet anaconda-client git
+        conda install --yes --quiet git
         echo "::endgroup::"
 
         echo "::group::Debugging information"

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -36,7 +36,7 @@ runs:
     - uses: conda-incubator/setup-miniconda@030178870c779d9e5e1b4e563269f3aa69b04081
       with:
         # conda not preinstalled in arm64 runners
-        miniconda-version: ${{ (runner.os == 'macOS' && runner.arch == 'ARM64') && 'latest' || null }}
+        miniconda-version: ${{ runner.os == 'macOS' && 'latest' || null }}
         auto-update-conda: true
 
     - name: Set output variables

--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -34,6 +34,11 @@ runs:
   using: composite
   steps:
     - uses: conda-incubator/setup-miniconda@030178870c779d9e5e1b4e563269f3aa69b04081
+      with:
+        # conda not preinstalled in arm64 runners
+        miniconda-version: ${{ (runner.os == 'macOS' && runner.arch == 'ARM64') && 'latest' || null }}
+        conda-build-version: latest
+        auto-update-conda: true
 
     - name: Set output variables
       id: vars
@@ -65,12 +70,10 @@ runs:
         echo "::group::Setting up environment"
         set -euo pipefail
         conda activate
-        conda update --yes --quiet conda
-        conda install --yes --quiet conda-build anaconda-client
         # git needs to be installed after conda-build
         # see https://github.com/conda/conda/issues/11758
         # see https://github.com/conda/actions/pull/47
-        conda install --yes --quiet git
+        conda install --yes --quiet anaconda-client git
         echo "::endgroup::"
 
         echo "::group::Debugging information"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The canary-release action breaks on osx-arm64 since conda is not pre-installed on those runners. See https://github.com/conda/conda/actions/runs/8819445678/job/24210668291?pr=13845

We resolve this by explicitly installing miniconda on osx-arm64.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
