### PR TITLE
Add `read-file` action

### DIFF
--- a/read-file/README.md
+++ b/read-file/README.md
@@ -1,0 +1,27 @@
+# Read JSON
+
+A composite GitHub Action to read a json file from a local or remote file.
+
+## GitHub Action Usage
+
+In your GitHub repository include this action in your workflows:
+
+```yaml
+- id: read_json
+  uses: conda/actions/read-json
+  with:
+    # [required]
+    # the relative path (or URL) to the YAML file to read
+    path: path/to/json.json
+    path: https://raw.githubusercontent.com/owner/repo/ref/path/to/json.json
+
+    # [optional]
+    # the keys to the value to extract
+    key: foo.bar.2.baz
+
+# if key provided get the value itself
+- run: echo ${{ steps.read_json.outputs.value }}
+
+# if no key provided get the entire YAML
+- run: echo ${{ fromJSON(steps.read_json.outputs.value)['key'] }}
+```

--- a/read-file/action.py
+++ b/read-file/action.py
@@ -1,0 +1,58 @@
+"""Read local or remote JSON file."""
+
+from __future__ import annotations
+
+import yaml
+import os
+import json
+import requests
+from typing import TYPE_CHECKING
+from argparse import ArgumentParser
+from pathlib import Path
+
+if TYPE_CHECKING:
+    from argparse import Namespace
+
+
+def parse_args() -> Namespace:
+    # parse CLI for inputs
+    parser = ArgumentParser()
+    parser.add_argument("file", type=str, help="Local path or remote URL to JSON file.")
+    parser.add_argument(
+        "--parser",
+        choices=["json", "yaml"],
+        help="Parser to use for the read file.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    try:
+        response = requests.get(args.file)
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        content = Path(args.file).read_text()
+    else:
+        content = response.text
+
+    # if a parser is defined we parse the content and dump it as JSON
+    if args.parser == "json":
+        content = json.loads(content)
+        content = json.dumps(content)
+    elif args.parser == "yaml":
+        content = yaml.safe_load(content)
+        content = json.dumps(content)
+
+    if output := os.getenv("GITHUB_OUTPUT"):
+        with Path(output).open("a") as fh:
+            fh.write(
+                f"content<<GITHUB_OUTPUT_content\n"
+                f"{content}\n"
+                f"GITHUB_OUTPUT_content\n"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/read-file/action.yml
+++ b/read-file/action.yml
@@ -1,0 +1,46 @@
+name: Read JSON
+description: Reads a local or remote JSON file.
+author: Anaconda Inc.
+branding:
+  icon: book-open
+  color: green
+
+inputs:
+  path:
+    description: Local path (or remote URL) to JSON file.
+    required: true
+outputs:
+  value:
+    description: Entire JSON file (if key is undefined) or the value for the provided key.
+    value: ${{ steps.read_json.outputs.value }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      with:
+        path: ~/.cache/pip
+        # invalidate the cache anytime a workflow changes
+        key: ${{ hashFiles('.github/workflows/*') }}
+
+    - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+      with:
+        python-version: '3.11'
+
+    - name: Install Dependencies
+      shell: bash
+      run: pip install --quiet -r ${{ github.action_path }}/requirements.txt
+
+    - name: Pip List
+      shell: bash
+      run: |
+        echo ::group::Pip List
+        pip list
+        echo ::endgroup::
+
+    - name: Read JSON
+      id: template
+      shell: bash
+      run: python ${{ github.action_path }}/action.py ${{ inputs.path }}
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/read-file/requirements.txt
+++ b/read-file/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml
+requests


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Adding a `read-file` action that will support reading a local or remote file and supports both JSON and Yaml but will also allow leaving the output as a plain string.

This action replaces `read-yaml`.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/actions/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/actions/blob/main/CONTRIBUTING.md -->
