### PR TITLE
Allow `with` to define any value type

### DIFF
--- a/template-files/action.py
+++ b/template-files/action.py
@@ -174,7 +174,16 @@ def read_config(args: Namespace) -> dict:
                             "with": {
                                 "type": "object",
                                 "patternProperties": {
-                                    r"\w+": {"type": "string"},
+                                    r"\w+": {
+                                        "type": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "object",
+                                            "array",
+                                            "null",
+                                        ],
+                                    },
                                 },
                             },
                         },


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The `template-files` supports a `with` key in the config file. This `with` key is the context used to template the given file. Previously the `with` context only allowed string values. Let's expand it to support any other type.

Example `config.yml`:
```yaml
some/repo:
  - src: templates/template.yml
    dst: ...
    with:
      conditional: true
```

Example `template.yml`:
```yaml
{% if conditional %}
- conditional value
{% endif %}
```

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/actions/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/actions/blob/main/CONTRIBUTING.md -->
