### PR TITLE
Remove fork check from `canary-release`

### DIFF
--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -57,8 +57,6 @@ runs:
         GITHUB_TOKEN: ${{ inputs.comment-token }}
 
     - name: Build & upload package
-      # make sure we don't run on forks
-      if: github.repository_owner == 'conda' || github.repository_owner == 'conda-incubator'
       id: build
       shell: bash -l {0}
       run: |


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

It is inappropriate for the GH Action itself to decide whether to run for forks.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/actions/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/actions/blob/main/CONTRIBUTING.md -->
