### PR TITLE
Improved templating audits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,21 @@
 [tool.codespell]
 # see https://github.com/codespell-project/codespell#using-a-config-file
 skip = '.git'
+
+[tool.ruff]
+target-version = "py39"
+
+[tool.ruff.lint]
+# see https://docs.astral.sh/ruff/rules/
+select = [
+  "E",  # pycodestyle errors
+  "F",  # pyflakes
+  "FA",  # flake8-future-annotations
+  "I",  # isort
+  "ISC",  # flake8-implicit-str-concat
+  "RUF100",  # Unused noqa directive
+  "T10",  # flake8-debugger
+  "TCH",  # flake8-type-checking
+  "UP",  # pyupgrade
+  "W",  # pycodestyle warnings
+]

--- a/template-files/action.py
+++ b/template-files/action.py
@@ -133,7 +133,7 @@ class SpyFileSystemLoader(FileSystemLoader):
     ) -> tuple[str, str, Callable[[], bool]]:
         try:
             # delegate to FileSystemLoader
-            return super().get_source(environment, stub)
+            value = super().get_source(environment, stub)
         except TemplateNotFound:
             # TemplateNotFound: template does not exist, mark it as missing
             self.count(environment, stub, -1)
@@ -141,6 +141,7 @@ class SpyFileSystemLoader(FileSystemLoader):
         else:
             # template found, mark it as used
             self.count(environment, stub, +1)
+            return value
 
 
 class SpyContext(Context):

--- a/template-files/action.py
+++ b/template-files/action.py
@@ -467,7 +467,7 @@ def iterate_config(
     return errors
 
 
-def dump_summary():
+def dump_summary(errors: int):
     # dump summary to GitHub Actions summary
     summary = os.getenv("GITHUB_STEP_SUMMARY")
     output = os.getenv("GITHUB_OUTPUT")
@@ -481,7 +481,7 @@ def dump_summary():
                 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-output-parameter
                 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings
                 f"summary<<GITHUB_OUTPUT_summary\n"
-                f"<details>\n"
+                f"<details {'open' if errors else ''}>\n"
                 f"<summary>Templating Audit</summary>\n"
                 f"\n"
                 f"{html}\n"
@@ -550,7 +550,7 @@ def main():
     if errors:
         perror(f"Got {errors} error(s)")
 
-    dump_summary()
+    dump_summary(errors)
     sys.exit(errors)
 
 

--- a/template-files/action.yml
+++ b/template-files/action.yml
@@ -30,7 +30,7 @@ runs:
       with:
         path: ~/.cache/pip
         # invalidate the cache anytime a workflow changes
-        key: ${{ hashFiles('.github/workflows/*') }}
+        key: ${{ github.workflow }}-${{ hashFiles('.github/workflows/*') }}
 
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

[context]: https://github.com/user-attachments/assets/c07c0183-0d53-4b62-ae89-710c4bc8b359
[optional]: https://github.com/user-attachments/assets/60fc36ba-8673-4873-b923-1f18d3ca4d64
[missing]: https://github.com/user-attachments/assets/09058510-d5f4-4348-bd3e-ed05652cdbba
[unused]: https://github.com/user-attachments/assets/88e0b85c-26aa-438f-aeb0-89872aefd4ad

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Whoa this became kinda complicated...no wonder I originally skipped this stuff.

I was reminded (in https://github.com/conda/conda-libmamba-solver/pull/588#issuecomment-2545830243) that I had chosen not to over engineered the templating engine but with the templates becoming more complex (and other besides myself monitoring the templating jobs) we might as well include all the bells and whistles to help ourselves when debugging.

[old]: https://github.com/user-attachments/assets/efb62d8c-7321-4091-a1a0-7be483d46ea4
[new]: https://github.com/user-attachments/assets/a3764c57-f59a-4a0c-afb1-a22d61c91968

<table>
<tr>
<td>

**Old Audit**

</td>
<td>

![old audit][old]

</td>
</tr>
<tr>
<td>

**New Audit**

</td>
<td>

![new audit][new]

</td>
</tr>
</table>

This change introduces a few key improvements:

1. we now watch for context usage so we can warn the user about missing variables, the context has 4 possible states:

    | State | Description | 
    |---|---|
    | ![context][context] | a variable that has been **successfully** used in the template |
    | ![optional][optional] | a variable that has **not** been defined but has a fallback value in the template |
    | ![missing][missing] | a variable that has **not** been defined and has no fallback value |
    | ![unused][unused] | a variable that is **not** used in the template |

2. if the templating produces errors we will leave the audit open by default, this will make the errors more noticeable
3. the template stubs table also includes counts of how many times the stubs are referenced

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/actions/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/actions/blob/main/CONTRIBUTING.md -->
