### PR TITLE
Allow conditional uploads in canary releases

### DIFF
--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: The path to the conda recipe passed to conda-build.
     required: false
     default: recipe
+  upload:
+    description: "Whether to upload to the target channel or not. Must be a boolean string: 'true' or 'false'."
+    required: false
+    default: 'true'
 runs:
   using: composite
   steps:
@@ -96,23 +100,26 @@ runs:
           )
         )
         echo "::endgroup::"
+        if [[ "${{ inputs.upload }}" == "true" ]]; then
+          echo "::group::Uploading package"
+          anaconda \
+            --token="${{ inputs.anaconda-org-token }}" \
+            upload \
+            --force \
+            --register \
+            --no-progress \
+            --user="${{ inputs.anaconda-org-channel }}" \
+            --label="${{ inputs.anaconda-org-label }}" \
+            "${PACKAGES[@]}"
+          echo "Uploaded the following files:"
+          basename -a "${PACKAGES[@]}"
+          echo "::endgroup::"
 
-        echo "::group::Uploading package"
-        anaconda \
-          --token="${{ inputs.anaconda-org-token }}" \
-          upload \
-          --force \
-          --register \
-          --no-progress \
-          --user="${{ inputs.anaconda-org-channel }}" \
-          --label="${{ inputs.anaconda-org-label }}" \
-          "${PACKAGES[@]}"
-        echo "Uploaded the following files:"
-        basename -a "${PACKAGES[@]}"
-        echo "::endgroup::"
-
-        echo "Use this command to try out the build:"
-        echo "conda install -c ${{ inputs.anaconda-org-channel }}/label/${{ inputs.anaconda-org-label }} ${{ inputs.package-name }}"
+          echo "Use this command to try out the build:"
+          echo "conda install -c ${{ inputs.anaconda-org-channel }}/label/${{ inputs.anaconda-org-label }} ${{ inputs.package-name }}"
+        else
+          echo "Skipping upload because 'upload != true'."
+        fi
 
     - name: Leave comment after build
       if: inputs.comment-token != '' && success()


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This would be useful to have for in-PR workflows where we want to test the recipe but not upload artifacts, so I can do `upload: ${{ github.ref_name == 'main' && 'true' || 'false' }}`.


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/actions/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/actions/blob/main/CONTRIBUTING.md -->
