### PR TITLE
Use an environment variable for the canary channel token

### DIFF
--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -63,6 +63,8 @@ runs:
     - name: Build & upload package
       id: build
       shell: bash -l {0}
+      env:
+        BINSTAR_API_TOKEN: ${{ inputs.anaconda-org-token }}
       run: |
         echo "::group::Setting up environment"
         set -euo pipefail
@@ -103,7 +105,6 @@ runs:
         if [[ "${{ inputs.upload }}" == "true" ]]; then
           echo "::group::Uploading package"
           anaconda \
-            --token="${{ inputs.anaconda-org-token }}" \
             upload \
             --force \
             --register \


### PR DESCRIPTION
### Description

Use an environment variable instead of a CLI argument to set the upload token for canary releases.

With the inclusion of `anaconda-auth` into Miniconda, the canary channel uploads are not working anymore because the `--token` input argument is not parsed. Storing the token in the `BINSTAR_API_TOKEN` environment variable should work though until a fix is available.