### PR TITLE
Update anaconda-client version and environment variable

### DIFF
--- a/canary-release/action.yml
+++ b/canary-release/action.yml
@@ -70,7 +70,7 @@ runs:
         set -euo pipefail
         conda activate
         conda update --yes --quiet conda
-        conda install --yes --quiet conda-build anaconda-client
+        conda install --yes --quiet conda-build anaconda-client=1.13.0
         # git needs to be installed after conda-build
         # see https://github.com/conda/conda/issues/11758
         # see https://github.com/conda/actions/pull/47
@@ -104,6 +104,7 @@ runs:
         echo "::endgroup::"
         if [[ "${{ inputs.upload }}" == "true" ]]; then
           echo "::group::Uploading package"
+          export ANACONDA_CLIENT_FORCE_STANDALONE=true
           anaconda \
             upload \
             --force \


### PR DESCRIPTION

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Pin anaconda-client version to 1.13.0 and set `ANACONDA_CLIENT_FORCE_STANDALONE` environment variable to make sure this'll work on all versions and platforms.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/actions/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/actions/blob/main/CONTRIBUTING.md -->
