### PR TITLE
Stop modifying synced lock workflow

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,20 +8,14 @@ on:
   schedule:
     - cron: 0 6 * * *
 
-permissions: {}
-
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   lock:
-    name: Lock inactive threads
     if: '!github.event.repository.fork'
     runs-on: ubuntu-slim
-    permissions:
-      issues: write  # Lock inactive issues.
-      pull-requests: write  # Lock inactive pull requests.
     steps:
       - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # v6.0.0
         with:

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -2,9 +2,9 @@
 # https://docs.zizmor.sh/configuration/
 #
 # Workflows synced from conda/infrastructure (cla.yml, issues.yml,
-# labels.yml, project.yml, stale.yml) cannot be modified in this
-# repo. Findings in those files are suppressed here; fixes should
-# be applied upstream in conda/infrastructure.
+# labels.yml, lock.yml, project.yml, stale.yml, update.yml) cannot
+# be modified in this repo. Findings in those files are suppressed
+# here; fixes should be applied upstream in conda/infrastructure.
 
 rules:
   dangerous-triggers:
@@ -27,6 +27,7 @@ rules:
       - cla.yml
       - issues.yml
       - labels.yml
+      - lock.yml
       - project.yml
       - stale.yml
       - update.yml
@@ -38,6 +39,7 @@ rules:
       - cla.yml
       - issues.yml
       - labels.yml
+      - lock.yml
       - stale.yml
       - update.yml
 
@@ -58,6 +60,7 @@ rules:
       - cla.yml
       - issues.yml
       - labels.yml
+      - lock.yml
       - project.yml
       - stale.yml
       - update.yml
@@ -69,6 +72,7 @@ rules:
       - cla.yml
       - issues.yml
       - labels.yml
+      - lock.yml
       - project.yml
       - stale.yml
       - update.yml


### PR DESCRIPTION
### Description

Follow-up to #361 after review feedback from @kenodegard.

`lock.yml` is synced from `conda/infrastructure`, so this PR restores it to the synced workflow content instead of keeping local permission/concurrency/job-name edits in this repository.

The corresponding `zizmor` findings are handled in `zizmor.yml` alongside the other synced workflow suppressions:

- `excessive-permissions`
- `undocumented-permissions`
- `anonymous-definition`
- `concurrency-limits`

This keeps the repository clean under `zizmor --persona=auditor .` without directly editing a synced workflow. Upstream auditor-persona cleanup remains tracked in #451.

Note: `conda/infrastructure#1328` already added baseline `zizmor` coverage upstream, but it does not enable the auditor persona. Running `zizmor 1.25.2 --persona=auditor .github/workflows` against current `conda/infrastructure` `origin/main` still reports the synced-workflow findings, including `lock.yml`.

Verification:

```
pre-commit run --all-files
zizmor --persona=auditor .
```
