### PR TITLE
Fix combine-durations for zero durations

### DIFF
--- a/combine-durations/combine_durations.py
+++ b/combine-durations/combine_durations.py
@@ -66,6 +66,8 @@ class DurationStats:
 
     @property
     def average_run_time(self) -> float:
+        if self.number_of_tests == 0:
+            return 0.0
         return self.total_run_time / self.number_of_tests
 
     def __iter__(self) -> Iterable[int, float]:

--- a/combine-durations/test_combine_durations.py
+++ b/combine-durations/test_combine_durations.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from combine_durations import (
+    DurationStats,
     aggregate_new_durations,
     aggregate_old_durations,
     read_durations,
@@ -67,6 +68,42 @@ def test_read_durations(path: Path) -> None:
     assert stats[os].number_of_tests == len(data)
     assert stats[os].total_run_time == sum(data.values())
     assert stats[os].average_run_time == sum(data.values()) / len(data)
+
+
+def test_duration_stats_empty() -> None:
+    stats = DurationStats()
+    assert stats.number_of_tests == 0
+    assert stats.total_run_time == 0.0
+    assert stats.average_run_time == 0.0
+    assert list(stats) == [0, 0.0, 0.0]
+
+
+def test_stats_table_with_missing_new_durations(tmp_path: Path) -> None:
+    """No downloaded artifacts, but existing duration files (conda-build failure)."""
+    durations_dir = tmp_path / "durations"
+    durations_dir.mkdir()
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+
+    for path in DURATIONS_DIR.glob("*.json"):
+        (durations_dir / path.name).write_text(path.read_text())
+
+    combined, new_stats = aggregate_new_durations(artifacts_dir)
+    _, old_stats = aggregate_old_durations(durations_dir, combined, unlink=False)
+
+    assert not new_stats
+    assert len(old_stats) == 2
+
+    # main() unpacks stats this way for the summary table
+    for os_name in sorted({*new_stats, *old_stats}):
+        ncount, ntotal, naverage = new_stats.get(os_name, DurationStats())
+        ocount, ototal, oaverage = old_stats.get(os_name, DurationStats())
+        assert ncount == 0
+        assert ntotal == 0.0
+        assert naverage == 0.0
+        assert ocount == 6
+        assert ototal > 0
+        assert oaverage > 0
 
 
 def test_aggregate_new_durations() -> None:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Handle combining durations when there are none to combine.

Closes #479 

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/actions/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/actions/blob/main/CONTRIBUTING.md -->
